### PR TITLE
Fix for macOS / more portable shebang

### DIFF
--- a/inoxunpack.py
+++ b/inoxunpack.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import json


### PR DESCRIPTION
1. /usr/bin/env is more common than /bin/env. Notably, macOS has no file at /bin/env.
2. The script does not seem to work with Python 2, throwing a Unicode-related error around line 38, so the shebang should specify Python 3.